### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/src/utils/command-exists.ts
+++ b/src/utils/command-exists.ts
@@ -73,7 +73,7 @@ const commandExistsWindowsSync = function (
 ): boolean {
   // Regex from Julio from: https://stackoverflow.com/questions/51494579/regex-windows-path-validator
   if (
-    !/^(?!(?:.*\s|.*\.|\W+)$)(?:[A-Za-z]:)?(?:[^\s"*:<>?|]+(?:[\/\\]+)?)+$/m.test(
+    !/^(?!(?:.*\s|.*\.|\W+)$)(?:[A-Za-z]:)?(?>[^\s"*:<>?|]+(?:[\/\\]+)?)+$/m.test(
       commandName
     )
   ) {


### PR DESCRIPTION
Potential fix for [https://github.com/binary-blazer/foxfork/security/code-scanning/4](https://github.com/binary-blazer/foxfork/security/code-scanning/4)

To fix the problem, we need to modify the regular expression to remove the ambiguity that leads to exponential backtracking. Specifically, we can replace the problematic part `[^\s"*:<>?|]+` with a more precise pattern that avoids nested quantifiers. One approach is to use a non-capturing group with an atomic group to prevent backtracking.

- Modify the regular expression on line 76 to use an atomic group `(?>...)` to prevent backtracking within the group.
- Ensure that the new regular expression maintains the same functionality and correctly validates Windows paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
